### PR TITLE
Spawned object knowledge and cleanup

### DIFF
--- a/cram_gazebo_utilities/src/package.lisp
+++ b/cram_gazebo_utilities/src/package.lisp
@@ -27,24 +27,20 @@
 
 (in-package :cl-user)
 
-(desig-props:def-desig-package
- cram-gazebo-utilities
- (:documentation "CRAM gazebo utilities")
- (:nicknames :cram-gu)
- (:use
-  #:common-lisp
-  #:cram-prolog
-  #:cram-process-modules
-  #:cram-plan-library
-;  #:crs
-  #:cut
-  #:desig
-;  #:designators-ros
-  #:roslisp
-  #:cram-plan-failures
-;  #:semantic-map-cache
-  )
+(desig-props:def-desig-package cram-gazebo-utilities
+  (:documentation "CRAM Gazebo Utilities")
+  (:nicknames :cram-gu)
+  (:use
+   #:common-lisp
+   #:cram-prolog
+   #:cram-process-modules
+   #:cram-plan-library
+   #:cut
+   #:desig
+   #:roslisp
+   #:cram-plan-failures)
   (:export init-cram-gazebo-utilities
            get-model-pose set-model-state
            spawn-gazebo-model object-in-world?
-           get-models gazebo-present))
+           get-models gazebo-present
+           spawned-object-description))

--- a/cram_gazebo_utilities/src/utils.lisp
+++ b/cram_gazebo_utilities/src/utils.lisp
@@ -24,17 +24,35 @@
 
 (in-package :cram-gazebo-utilities)
 
+
+;;;
+;;; Class definitions
+;;;
+
 (defclass spawned-object ()
   ((id :reader id :initarg :id)
    (description :reader description :initarg :description)))
 
+
+;;;
+;;; Global variables
+;;;
+
 (defvar *spawned-objects* (make-hash-table :test 'equal))
+
+
+;;;
+;;; Functions: Spawned object knowledge
+;;;
+
 (defun clear-spawned-object-knowledge ()
   (setf *spawned-objects* (make-hash-table :test 'equal)))
+
 (defun register-spawned-object (object-id description)
   (setf (gethash object-id *spawned-objects*)
         (make-instance 'spawned-object
                        :id object-id :description description)))
+
 (defun unregister-spawned-object (object-id)
   (remhash object-id *spawned-objects*))
 
@@ -43,27 +61,39 @@
     (when spawned-object
       (description spawned-object))))
 
+
+;;;
+;;; Functions: Model state, spawning, deleting
+;;;
+
 (defun set-model-state (model-name new-pose)
   (call-service "gazebo/set_model_state"
                 'gazebo_msgs-srv:setmodelstate
-                :model_state (make-msg "gazebo_msgs/ModelState"
-                                       :model_name model-name
-                                       :pose (cl-transforms-stamped:to-msg new-pose)
-                                       :reference_frame (cl-transforms-stamped:frame-id new-pose))))
+                :model_state
+                (make-msg "gazebo_msgs/ModelState"
+                          :model_name model-name
+                          :pose (cl-transforms-stamped:to-msg new-pose)
+                          :reference_frame (cl-transforms-stamped:frame-id new-pose))))
 
-(defun spawn-gazebo-model (name pose urdf-file)
-
+(defun spawn-gazebo-model (name pose urdf-file &key description)
   (call-service "gazebo/spawn_urdf_model"
                 'gazebo_msgs-srv:spawnmodel
                 :model_name name
                 :model_xml (file-string urdf-file)
-                :initial_pose (cl-transforms-stamped:to-msg (cl-tf:pose-stamped->pose pose))
-                :reference_frame (cl-transforms-stamped:frame-id pose)))
+                :initial_pose (cl-transforms-stamped:to-msg
+                               (cl-tf:pose-stamped->pose pose))
+                :reference_frame (cl-transforms-stamped:frame-id pose))
+  (register-spawned-object name description))
 
 (defun delete-gazebo-model (name)
   (call-service "gazebo/delete_model"
                 'gazebo_msgs-srv:deletemodel
-                :model_name name))
+                :model_name name)
+  (unregister-spawned-object name))
+
+;;;
+;;; Functions: Utility
+;;;
 
 (defun file-string (path)
   (with-open-file (s path)
@@ -75,6 +105,11 @@
 
 (defun gazebo-present ()
   (roslisp:wait-for-service "gazebo/spawn_urdf_model" 0.25))
+
+
+;;;
+;;; Functions: Joint manipulation
+;;;
 
 (defun set-joint-effort (joint effort &key (duration 2.0))
   (call-service "gazebo/apply_joint_effort"

--- a/cram_gazebo_utilities/src/utils.lisp
+++ b/cram_gazebo_utilities/src/utils.lisp
@@ -24,6 +24,25 @@
 
 (in-package :cram-gazebo-utilities)
 
+(defclass spawned-object ()
+  ((id :reader id :initarg :id)
+   (description :reader description :initarg :description)))
+
+(defvar *spawned-objects* (make-hash-table :test 'equal))
+(defun clear-spawned-object-knowledge ()
+  (setf *spawned-objects* (make-hash-table :test 'equal)))
+(defun register-spawned-object (object-id description)
+  (setf (gethash object-id *spawned-objects*)
+        (make-instance 'spawned-object
+                       :id object-id :description description)))
+(defun unregister-spawned-object (object-id)
+  (remhash object-id *spawned-objects*))
+
+(defun spawned-object-description (object-id)
+  (let ((spawned-object (gethash object-id *spawned-objects*)))
+    (when spawned-object
+      (description spawned-object))))
+
 (defun set-model-state (model-name new-pose)
   (call-service "gazebo/set_model_state"
                 'gazebo_msgs-srv:setmodelstate
@@ -33,6 +52,7 @@
                                        :reference_frame (cl-transforms-stamped:frame-id new-pose))))
 
 (defun spawn-gazebo-model (name pose urdf-file)
+
   (call-service "gazebo/spawn_urdf_model"
                 'gazebo_msgs-srv:spawnmodel
                 :model_name name

--- a/cram_gazebo_utilities/src/utils.lisp
+++ b/cram_gazebo_utilities/src/utils.lisp
@@ -9,9 +9,6 @@
 ;;;     * Redistributions in binary form must reproduce the above copyright
 ;;;       notice, this list of conditions and the following disclaimer in the
 ;;;       documentation and/or other materials provided with the distribution.
-;;;     * Neither the name of Willow Garage, Inc. nor the names of its
-;;;       contributors may be used to endorse or promote products derived from
-;;;       this software without specific prior written permission.
 ;;; 
 ;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 ;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
Cleaned up most of the gazebo-related packages; also, spawned objects can now be annotated with extra knowledge (aka description) that will transparently be appended to their individual description when perceiving them.

Also, removed the requirement from the BSD clause to not mention the original author for promotional purposes. It was "Willow Garage" still anyway, so legally no change here.
