### PR TITLE
Fixes for function names and designator properties

### DIFF
--- a/gazebo_perception_process_module/src/designator.lisp
+++ b/gazebo_perception_process_module/src/designator.lisp
@@ -29,7 +29,7 @@
 (in-package :gazebo-perception-pm)
 
 (defun designator-model-pose (name)
-  (let ((found-objects (find-object :object-name name)))
+  (let ((found-objects (find-objects :object-name name)))
     (when found-objects
       (object-pose (first found-objects)))))
 

--- a/gazebo_perception_process_module/src/process-module.lisp
+++ b/gazebo_perception_process_module/src/process-module.lisp
@@ -189,7 +189,7 @@ given, all known objects from the knowledge base are returned."
     (cpl:mapcar-clean (lambda (model)
                         (with-slots ((model-name desig::object-identifier) (pose desig::pose)) model
                           (let* ((pose (cram-gazebo-utilities:get-model-pose model-name))
-                                 (location (make-designator :location `((:at ,pose))))
+                                 (location (make-designator :location `((:pose ,pose))))
                                  (description (cram-gazebo-utilities:spawned-object-description model-name))
                                  (description-type (cadr (find :type description :test (lambda (x y)
                                                                                          (eql x (car y))))))


### PR DESCRIPTION
A function name was wrong (outdated) and a designator property wasn't being set correctly
