### PR TITLE
Object belief when perceiving, plus spawning/deleting Gazebo objects

### DIFF
--- a/cram_gazebo_utilities/src/package.lisp
+++ b/cram_gazebo_utilities/src/package.lisp
@@ -43,4 +43,6 @@
            get-model-pose set-model-state
            spawn-gazebo-model object-in-world?
            get-models gazebo-present
-           spawned-object-description))
+           spawned-object-description
+           spawned-objects
+           delete-spawned-objects))

--- a/cram_gazebo_utilities/src/package.lisp
+++ b/cram_gazebo_utilities/src/package.lisp
@@ -45,4 +45,5 @@
            get-models gazebo-present
            spawned-object-description
            spawned-objects
-           delete-spawned-objects))
+           delete-spawned-objects
+           model-present))

--- a/cram_gazebo_utilities/src/utils.lisp
+++ b/cram_gazebo_utilities/src/utils.lisp
@@ -61,6 +61,15 @@
     (when spawned-object
       (description spawned-object))))
 
+(defun spawned-objects ()
+  (loop for name being the hash-keys of *spawned-objects*
+        collect name))
+
+(defun delete-spawned-objects ()
+  (dolist (object-id (spawned-objects))
+    (delete-gazebo-model object-id))
+  (clear-spawned-object-knowledge))
+
 
 ;;;
 ;;; Functions: Model state, spawning, deleting
@@ -90,6 +99,14 @@
                 'gazebo_msgs-srv:deletemodel
                 :model_name name)
   (unregister-spawned-object name))
+
+(defun model-present (name)
+  (with-fields (success)
+      (call-service "gazebo/get_model_state"
+                    'gazebo_msgs-srv:getmodelstate
+                    :model_name name
+                    :relative_entity_name "")
+    success))
 
 ;;;
 ;;; Functions: Utility

--- a/gazebo_perception_process_module/src/process-module.lisp
+++ b/gazebo_perception_process_module/src/process-module.lisp
@@ -172,6 +172,9 @@ given, all known objects from the knowledge base are returned."
          ;; objects instead of the currently visible ones. This is
          ;; intended behavior and is related to problems in Gazebo
          ;; 2.2.3 w.r.t. raytracing code.
+         ;(filtered-model-names (filter-models-by-field-of-view
+         ;                       filtered-model-names))
+         )
          (filtered-model-names (filter-models-by-field-of-view
                                 filtered-model-names)))
     (mapcar (lambda (model-name)

--- a/gazebo_perception_process_module/src/process-module.lisp
+++ b/gazebo_perception_process_module/src/process-module.lisp
@@ -168,13 +168,12 @@ given, all known objects from the knowledge base are returned."
          (filtered-model-names (filter-models-by-name
                                 filtered-model-names
                                 :template-name object-name))
-         ;; TODO: Doesn't work at the moment (Gazebo segfaults every
-         ;; now and then when active; this isn't blocking development
-         ;; right now, but should be fixed soonish to better
-         ;; incorporate it).
-         ;(filtered-model-names (filter-models-by-field-of-view
-         ;                       filtered-model-names))
-         )
+         ;; TODO: Fix this external component; it returns all spawned
+         ;; objects instead of the currently visible ones. This is
+         ;; intended behavior and is related to problems in Gazebo
+         ;; 2.2.3 w.r.t. raytracing code.
+         (filtered-model-names (filter-models-by-field-of-view
+                                filtered-model-names)))
     (mapcar (lambda (model-name)
               (let ((pose (cram-gazebo-utilities:get-model-pose model-name)))
                 (make-instance 'gazebo-designator-shape-data


### PR DESCRIPTION
Spawning and deleting objects in Gazebo from `cram_gazebo_utilities`
Also, manipulating the bullet belief state when objects were detected to properly reflect these
Plus minor
